### PR TITLE
Add Timeout In BGThread Wait

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -180,7 +180,7 @@ void ThreadPoolImpl::Impl::BGThread(size_t thread_id) {
     // Stop waiting if the thread needs to do work or needs to terminate.
     while (!exit_all_threads_ && !IsLastExcessiveThread(thread_id) &&
            (queue_.empty() || IsExcessiveThread(thread_id))) {
-      bgsignal_.wait(lock);
+      bgsignal_.wait_for(lock, std::chrono::seconds(10));
     }
 
     if (exit_all_threads_) {  // mechanism to let BG threads exit safely


### PR DESCRIPTION
Rather than waiting for a signal forever, allow a timeout to fire every
ten seconds; if we timeout, check the conditionals and, if necessessary,
wait again.