### PR TITLE
Add A Timeout To BGThread Wait In Thread Pool

### DIFF
--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -177,7 +177,7 @@ void ThreadPoolImpl::Impl::BGThread(size_t thread_id) {
     // Stop waiting if the thread needs to do work or needs to terminate.
     while (!exit_all_threads_ && !IsLastExcessiveThread(thread_id) &&
            (queue_.empty() || IsExcessiveThread(thread_id))) {
-      bgsignal_.wait(lock);
+      bgsignal_.wait_for(lock, std::chrono::seconds(10));
     }
 
     if (exit_all_threads_) {  // mechanism to let BG threads exit safely


### PR DESCRIPTION
We don't want to wait forever; we should wake up periodically (every 10
seconds) and check the conditions again in case we miss a signal.